### PR TITLE
Fix possible false return on env#envAnyDefined

### DIFF
--- a/src/util/env.ts
+++ b/src/util/env.ts
@@ -3,15 +3,7 @@ function envIsDefined (key: string): boolean {
 }
 
 function envAnyDefined (...keys: string[]): boolean {
-    let ok = true
-
-    for (const key of keys) {
-        if (typeof process.env[key] === 'undefined') {
-            ok = false
-        }
-    }
-
-    return ok
+    return keys.some(envIsDefined)
 }
 
 export {


### PR DESCRIPTION
envAnyDefined had the potential to return a false `true` value. This simplifies the code to call envIsDefined on all keys using the .some() method.